### PR TITLE
ci(pre-commit-config): Fix ruff-check hook to run isort extending the…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,8 @@ repos:
     hooks:
       - id: ruff-check
         args:
-          - --select I
+          - --extend-select
+          - I
           - --fix
           - --show-fixes
       - id: ruff-format


### PR DESCRIPTION
… defaults, not replacing them